### PR TITLE
Add styling to tel input type

### DIFF
--- a/css/wbounce.scss
+++ b/css/wbounce.scss
@@ -171,7 +171,17 @@ $white: #fff;
       border: 1px solid #ccc;
       -webkit-font-smoothing: antialiased;
     }
-
+    
+    input[type=tel] {
+      color: #999;
+      padding: 12px;
+      font-size: 15px;
+      width: 300px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      -webkit-font-smoothing: antialiased;
+    }
+    
     input[type=text] {
       padding: 12px;
       font-size: 1.2em;


### PR DESCRIPTION
Noticed this while using a contact form shortcode inside the modal, styling was not applied to the "tel" input type.

@kevinweber 
